### PR TITLE
add type definitions for react-ga

### DIFF
--- a/react-ga/react-ga.d.ts
+++ b/react-ga/react-ga.d.ts
@@ -1,0 +1,28 @@
+declare namespace __reactGA {
+    export interface EventArgs {
+        category: string;
+        action: string;
+        label?: string;
+        value?: number;
+        nonInteraction?: boolean;
+    }
+
+    export interface InitializeOptions {
+        debug?: boolean;
+        gaOptions?: gaOptions;
+    }
+
+    export interface gaOptions {
+        userId?: number;
+        cookieDomain?: string;
+    }
+
+    export function initialize(trackingCode: string, options?: InitializeOptions): void;
+    export function pageview(path: string): void;
+    export function modalview(name: string): void;
+    export function event(args: EventArgs): void;
+}
+
+declare module 'react-ga' {
+    export = __reactGA;
+}


### PR DESCRIPTION
As part of the [Google Analytics PR LNG-847](https://github.com/detroit-labs/lineage-frontend/pull/535) we will need to update the typings for react-ga since it doesn't appear to contain the appropriate methods already. 

Add the following 

    export interface InitializeOptions {
        debug?: boolean;
        gaOptions?: gaOptions;
    }

    export interface gaOptions {
        userId?: number;
        cookieDomain?: string;
    }

To conform to [docs](https://github.com/react-ga/react-ga)

![screen shot 2016-12-19 at 5 00 17 pm](https://cloud.githubusercontent.com/assets/6778101/21330705/c0db9f22-c60c-11e6-8a3c-eade1b567b6a.png)