### PR TITLE
LNG-2103 Adding typings for superSelectField filters

### DIFF
--- a/material-ui-superselectfield/material-ui-superselectfield.d.ts
+++ b/material-ui-superselectfield/material-ui-superselectfield.d.ts
@@ -1,0 +1,22 @@
+declare module "material-ui-superselectfield" {
+    import * as React from "react"
+
+    interface IMaterialUISuperSelectFieldProps {
+        multiple: boolean;
+        key: string;
+        name: string;
+        onChange: (selectedValues: any[], name: string) => void;
+        value: object[];
+        selectionsRenderer: (values: any[]) => void;
+        checkPosition: string;
+        hintText: string;
+        nb2show: number;
+        hoverColor: string;
+        elementHeight: number;
+        style: { marginBottom: number };
+        innerDivStyle: { padding: string, whiteSpace: string };
+        selectedMenuItemStyle: { color: string };
+    }
+
+    export default class SuperSelectField extends React.Component<IMaterialUISuperSelectFieldProps, any> {}
+}

--- a/material-ui-superselectfield/material-ui-superselectfield.d.ts
+++ b/material-ui-superselectfield/material-ui-superselectfield.d.ts
@@ -2,20 +2,43 @@ declare module "material-ui-superselectfield" {
     import * as React from "react"
 
     interface IMaterialUISuperSelectFieldProps {
-        multiple: boolean;
-        key: string;
         name: string;
-        onChange: (selectedValues: any[], name: string) => void;
-        value: object[];
-        selectionsRenderer: (values: any[]) => void;
-        checkPosition: string;
-        hintText: string;
-        nb2show: number;
-        hoverColor: string;
-        elementHeight: number;
-        style: { marginBottom: number };
-        innerDivStyle: { padding: string, whiteSpace: string };
-        selectedMenuItemStyle: { color: string };
+        value: object[] | object | null;
+        multiple?: boolean;
+        key?: string;
+        onChange?: (...args: any[]) => void;
+        selectionsRenderer?: (...args: any[]) => void;
+        checkPosition?: string;
+        hintText?: string;
+        nb2show?: number;
+        elementHeight?: number;
+        style?: Object;
+        innerDivStyle?: Object;
+        selectedMenuItemStyle?: Object;
+        hoverColor?: string;
+        floatingLabel?: any;
+        hintTextAutocomplete?: string;
+        noMatchFound?: string;
+        anchorOrigin?: { vertical: string, horizontal: string };
+        canAutoPosition?: boolean;
+        disabled?: boolean;
+        onAutoCompleteTyping?: (...args: any[]) => void;
+        children?: any;
+        showAutocompleteThreshold?: number;
+        autocompleteFilter?: (...args: any[]) => void;
+        useLayerForClickAway?: boolean;
+        menuStyle?: Object;
+        menuGroupStyle?: Object;
+        menuFooterStyle?: Object;
+        menuCloseButton?: any;
+        checkedIcon?: any;
+        unCheckedIcon?: any;
+        floatingLabelStyle?: Object;
+        floatingLabelFocusStyle?: Object;
+        underlineStyle?: Object;
+        underlineFocusStyle?: Object;
+        autocompleteUnderlineStyle?: Object;
+        autocompleteUnderlineFocusStyle?: Object;
     }
 
     export default class SuperSelectField extends React.Component<IMaterialUISuperSelectFieldProps, any> {}


### PR DESCRIPTION
### Explanation

This PR adds in typings for the superSelectField.  Once this branch is merged, we will need to update the FE to account for the new typings file.

### Testing Steps

Please QA before merging!!!

1.  Check out the master branch of the FE.
2.  Change the `typings.json` file by including the following line within the global dependencies:
`"material-ui-superselectfield": "https://raw.githubusercontent.com/detroit-labs/typed-things/LNG-2103-SuperSelectField-typings/material-ui-superselectfield/material-ui-superselectfield.d.ts#0a46ba"`   (this points to the file updated on this branch)
3.  Run `yarn typings`.  You should see the ` material-ui-superselectfield (global)` installed during this step.
4.  Delete the following file from the FE branch code `app/ambient.d.ts`  (this contains an empty exported material-ui-supserselectfield).
5.  Spin up master branch of your MW and the FE branch.
6.  Make sure no errors occur during compiling.  Additionally, open up your console as soon as you bring up the web app.
7.  Choose a single facility and navigate to Capacity Utilization.
8.  Open the filter and select different filters, etc.  Test out and ensure no errors show in the console.
9.  An additional test you can do is to change some of the typings in the `typings/globals/material-ui-superselectfield/index.d.ts` file, which should cause errors with the `Filter` component compiling (from the `filterDialog.ts` file).

### Screenshots

The component can "see" all of its properties now!  🙌 

![screen shot 2017-10-11 at 3 35 49 pm](https://user-images.githubusercontent.com/10436592/31462260-26bf5678-ae9a-11e7-9ede-79d63f882128.png)
